### PR TITLE
Forge mod support expansion (fabric coming soon™)

### DIFF
--- a/assets/abundance/models/block/flowering_redbud_log.json
+++ b/assets/abundance/models/block/flowering_redbud_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "abundance:block/redbud_log_top",
+        "side": "abundance:block/flowering_redbud_log",
+		"particle": "abundance:block/flowering_redbud_log"
+    }
+}

--- a/assets/abundance/models/block/jacaranda_log.json
+++ b/assets/abundance/models/block/jacaranda_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "abundance:block/jacaranda_log_top",
+        "side": "abundance:block/jacaranda_log",
+		"particle": "abundance:block/jacaranda_log"
+    }
+}

--- a/assets/abundance/models/block/redbud_log.json
+++ b/assets/abundance/models/block/redbud_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "abundance:block/redbud_log_top",
+        "side": "abundance:block/redbud_log",
+		"particle": "abundance:block/redbud_log"
+    }
+}

--- a/assets/abundance/models/block/stripped_jacaranda_log.json
+++ b/assets/abundance/models/block/stripped_jacaranda_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "abundance:block/stripped_jacaranda_log_top",
+        "side": "abundance:block/stripped_jacaranda_log",
+		"particle": "abundance:block/stripped_jacaranda_log"
+    }
+}

--- a/assets/abundance/models/block/stripped_redbud_log.json
+++ b/assets/abundance/models/block/stripped_redbud_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "abundance:block/stripped_redbud_log_top",
+        "side": "abundance:block/stripped_redbud_log",
+		"particle": "abundance:block/stripped_redbud_log"
+    }
+}

--- a/assets/atmospheric/models/block/aspen_log.json
+++ b/assets/atmospheric/models/block/aspen_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/aspen_log_top",
+        "side": "atmospheric:block/aspen_log",
+		"particle": "atmospheric:block/aspen_log"
+    }
+}

--- a/assets/atmospheric/models/block/grimwood_log.json
+++ b/assets/atmospheric/models/block/grimwood_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/grimwood_log_top",
+        "side": "atmospheric:block/grimwood_log",
+		"particle": "atmospheric:block/grimwood_log"
+    }
+}

--- a/assets/atmospheric/models/block/kousa_log.json
+++ b/assets/atmospheric/models/block/kousa_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/kousa_log_top",
+        "side": "atmospheric:block/kousa_log",
+		"particle": "atmospheric:block/kousa_log"
+    }
+}

--- a/assets/atmospheric/models/block/morado_log.json
+++ b/assets/atmospheric/models/block/morado_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/morado_log_top",
+        "side": "atmospheric:block/morado_log",
+		"particle": "atmospheric:block/morado_log"
+    }
+}

--- a/assets/atmospheric/models/block/rosewood_log.json
+++ b/assets/atmospheric/models/block/rosewood_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/rosewood_log_top",
+        "side": "atmospheric:block/rosewood_log",
+		"particle": "atmospheric:block/rosewood_log"
+    }
+}

--- a/assets/atmospheric/models/block/stripped_aspen_log.json
+++ b/assets/atmospheric/models/block/stripped_aspen_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/stripped_aspen_log_top",
+        "side": "atmospheric:block/stripped_aspen_log",
+		"particle": "atmospheric:block/stripped_aspen_log"
+    }
+}

--- a/assets/atmospheric/models/block/stripped_grimwood_log.json
+++ b/assets/atmospheric/models/block/stripped_grimwood_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/stripped_grimwood_log_top",
+        "side": "atmospheric:block/stripped_grimwood_log",
+		"particle": "atmospheric:block/stripped_grimwood_log"
+    }
+}

--- a/assets/atmospheric/models/block/stripped_kousa_log.json
+++ b/assets/atmospheric/models/block/stripped_kousa_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/stripped_kousa_log_top",
+        "side": "atmospheric:block/stripped_kousa_log",
+		"particle": "atmospheric:block/stripped_kousa_log"
+    }
+}

--- a/assets/atmospheric/models/block/stripped_morado_log.json
+++ b/assets/atmospheric/models/block/stripped_morado_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/stripped_morado_log_top",
+        "side": "atmospheric:block/stripped_morado_log",
+		"particle": "atmospheric:block/stripped_morado_log"
+    }
+}

--- a/assets/atmospheric/models/block/stripped_rosewood_log.json
+++ b/assets/atmospheric/models/block/stripped_rosewood_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/stripped_rosewood_log_top",
+        "side": "atmospheric:block/stripped_rosewood_log",
+		"particle": "atmospheric:block/stripped_rosewood_log"
+    }
+}

--- a/assets/atmospheric/models/block/stripped_yucca_log.json
+++ b/assets/atmospheric/models/block/stripped_yucca_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/stripped_yucca_log_top",
+        "side": "atmospheric:block/stripped_yucca_log",
+		"particle": "atmospheric:block/stripped_yucca_log"
+    }
+}

--- a/assets/atmospheric/models/block/watchful_aspen_log.json
+++ b/assets/atmospheric/models/block/watchful_aspen_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/aspen_log_top",
+        "side": "atmospheric:block/watchful_aspen_log",
+		"particle": "atmospheric:block/watchful_aspen_log"
+    }
+}

--- a/assets/atmospheric/models/block/yucca_log.json
+++ b/assets/atmospheric/models/block/yucca_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "atmospheric:block/yucca_log_top",
+        "side": "atmospheric:block/yucca_log",
+		"particle": "atmospheric:block/yucca_log"
+    }
+}

--- a/assets/autumnity/models/block/maple_log.json
+++ b/assets/autumnity/models/block/maple_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "autumnity:block/maple_log_top",
+        "side": "autumnity:block/maple_log",
+		"particle": "autumnity:block/maple_log"
+    }
+}

--- a/assets/autumnity/models/block/sappy_maple_log.json
+++ b/assets/autumnity/models/block/sappy_maple_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "autumnity:block/stripped_maple_log_top",
+        "side": "autumnity:block/sappy_maple_log",
+		"particle": "autumnity:block/sappy_maple_log"
+    }
+}

--- a/assets/autumnity/models/block/stripped_maple_log.json
+++ b/assets/autumnity/models/block/stripped_maple_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "autumnity:block/stripped_maple_log_top",
+        "side": "autumnity:block/stripped_maple_log",
+		"particle": "autumnity:block/stripped_maple_log"
+    }
+}

--- a/assets/bayou_blues/models/block/cypress_log.json
+++ b/assets/bayou_blues/models/block/cypress_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "bayou_blues:block/cypress_log_top",
+        "side": "bayou_blues:block/cypress_log",
+		"particle": "bayou_blues:block/cypress_log"
+    }
+}

--- a/assets/bayou_blues/models/block/stripped_cypress_log.json
+++ b/assets/bayou_blues/models/block/stripped_cypress_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "bayou_blues:block/stripped_cypress_log_top",
+        "side": "bayou_blues:block/stripped_cypress_log",
+		"particle": "bayou_blues:block/stripped_cypress_log"
+    }
+}

--- a/assets/endergetic/models/block/glowing_poise_stem.json
+++ b/assets/endergetic/models/block/glowing_poise_stem.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "endergetic:block/poise_stem_top",
+        "side": "endergetic:block/poise_stem_glowing",
+		"particle": "endergetic:block/poise_stem_glowing"
+    }
+}

--- a/assets/endergetic/models/block/poise_stem.json
+++ b/assets/endergetic/models/block/poise_stem.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "endergetic:block/poise_stem_top",
+        "side": "endergetic:block/poise_stem",
+		"particle": "endergetic:block/poise_stem"
+    }
+}

--- a/assets/endergetic/models/block/stripped_poise_stem.json
+++ b/assets/endergetic/models/block/stripped_poise_stem.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "endergetic:block/poise_stem_stripped_top",
+        "side": "endergetic:block/poise_stem_stripped",
+		"particle": "endergetic:block/poise_stem_stripped"
+    }
+}

--- a/assets/enhanced_mushrooms/models/block/brown_mushroom_stem.json
+++ b/assets/enhanced_mushrooms/models/block/brown_mushroom_stem.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "enhanced_mushrooms:block/brown_mushroom_stem_top",
+        "side": "enhanced_mushrooms:block/brown_mushroom_stem",
+		"particle": "enhanced_mushrooms:block/brown_mushroom_stem"
+    }
+}

--- a/assets/enhanced_mushrooms/models/block/glowshroom_stem.json
+++ b/assets/enhanced_mushrooms/models/block/glowshroom_stem.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "enhanced_mushrooms:block/glowshroom_stem_top",
+        "side": "quark:block/glowshroom_stem",
+		"particle": "quark:block/glowshroom_stem"
+    }
+}

--- a/assets/enhanced_mushrooms/models/block/red_mushroom_stem.json
+++ b/assets/enhanced_mushrooms/models/block/red_mushroom_stem.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "enhanced_mushrooms:block/red_mushroom_stem_top",
+        "side": "enhanced_mushrooms:block/red_mushroom_stem",
+		"particle": "enhanced_mushrooms:block/red_mushroom_stem"
+    }
+}

--- a/assets/enhanced_mushrooms/models/block/stripped_brown_mushroom_stem.json
+++ b/assets/enhanced_mushrooms/models/block/stripped_brown_mushroom_stem.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "enhanced_mushrooms:block/stripped_brown_mushroom_stem_top",
+        "side": "enhanced_mushrooms:block/stripped_brown_mushroom_stem",
+		"particle": "enhanced_mushrooms:block/stripped_brown_mushroom_stem"
+    }
+}

--- a/assets/enhanced_mushrooms/models/block/stripped_glowshroom_stem.json
+++ b/assets/enhanced_mushrooms/models/block/stripped_glowshroom_stem.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "enhanced_mushrooms:block/stripped_glowshroom_stem_top",
+        "side": "enhanced_mushrooms:block/stripped_glowshroom_stem",
+		"particle": "enhanced_mushrooms:block/stripped_glowshroom_stem"
+    }
+}

--- a/assets/enhanced_mushrooms/models/block/stripped_red_mushroom_stem.json
+++ b/assets/enhanced_mushrooms/models/block/stripped_red_mushroom_stem.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "enhanced_mushrooms:block/stripped_red_mushroom_stem_top",
+        "side": "enhanced_mushrooms:block/stripped_red_mushroom_stem",
+		"particle": "enhanced_mushrooms:block/stripped_red_mushroom_stem"
+    }
+}

--- a/assets/environmental/models/block/cherry_log.json
+++ b/assets/environmental/models/block/cherry_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "environmental:block/cherry_log_top",
+        "side": "environmental:block/cherry_log",
+		"particle": "environmental:block/cherry_log"
+    }
+}

--- a/assets/environmental/models/block/stripped_cherry_log.json
+++ b/assets/environmental/models/block/stripped_cherry_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "environmental:block/stripped_cherry_log_top",
+        "side": "environmental:block/stripped_cherry_log",
+		"particle": "environmental:block/stripped_cherry_log"
+    }
+}

--- a/assets/environmental/models/block/stripped_willow_log.json
+++ b/assets/environmental/models/block/stripped_willow_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "environmental:block/stripped_willow_log_top",
+        "side": "environmental:block/stripped_willow_log",
+		"particle": "environmental:block/stripped_willow_log"
+    }
+}

--- a/assets/environmental/models/block/stripped_wisteria_log.json
+++ b/assets/environmental/models/block/stripped_wisteria_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "environmental:block/stripped_wisteria_log_top",
+        "side": "environmental:block/stripped_wisteria_log",
+		"particle": "environmental:block/stripped_wisteria_log"
+    }
+}

--- a/assets/environmental/models/block/willow_log.json
+++ b/assets/environmental/models/block/willow_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "environmental:block/willow_log_top",
+        "side": "environmental:block/willow_log",
+		"particle": "environmental:block/willow_log"
+    }
+}

--- a/assets/environmental/models/block/wisteria_log.json
+++ b/assets/environmental/models/block/wisteria_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "environmental:block/wisteria_log_top",
+        "side": "environmental:block/wisteria_log",
+		"particle": "environmental:block/wisteria_log"
+    }
+}

--- a/assets/naturesaura/blockstates/ancient_log.json
+++ b/assets/naturesaura/blockstates/ancient_log.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "axis=y": {"model": "naturesaura:block/ancient_log"},
+        "axis=z": {"model": "naturesaura:block/ancient_log", "x": 90},
+        "axis=x": {"model": "naturesaura:block/ancient_log", "x": 90, "y": 90}
+    }
+}

--- a/assets/naturesaura/blockstates/stripped_ancient_log.json
+++ b/assets/naturesaura/blockstates/stripped_ancient_log.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "axis=y":    { "model": "naturesaura:block/ancient_log" },
+        "axis=z":     { "model": "naturesaura:block/ancient_log", "x": 90 },
+        "axis=x":     { "model": "naturesaura:block/ancient_log", "x": 90, "y": 90 }
+    }
+}

--- a/assets/naturesaura/models/block/ancient_log.json
+++ b/assets/naturesaura/models/block/ancient_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "naturesaura:block/ancient_log_top",
+        "side": "naturesaura:block/ancient_log",
+		"particle": "naturesaura:block/ancient_log"
+    }
+}

--- a/assets/silentgear/blockstates/netherwood_log.json
+++ b/assets/silentgear/blockstates/netherwood_log.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "axis=y": {"model": "silentgear:block/netherwood_log"},
+        "axis=z": {"model": "silentgear:block/netherwood_log", "x": 90},
+        "axis=x": {"model": "silentgear:block/netherwood_log", "x": 90, "y": 90}
+    }
+}

--- a/assets/silentgear/blockstates/stripped_netherwood_log.json
+++ b/assets/silentgear/blockstates/stripped_netherwood_log.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "axis=y":    { "model": "silentgear:block/netherwood_log" },
+        "axis=z":     { "model": "silentgear:block/netherwood_log", "x": 90 },
+        "axis=x":     { "model": "silentgear:block/netherwood_log", "x": 90, "y": 90 }
+    }
+}

--- a/assets/silentgear/models/block/netherwood_log.json
+++ b/assets/silentgear/models/block/netherwood_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "silentgear:block/netherwood_log_top",
+        "side": "silentgear:block/netherwood_log",
+		"particle": "silentgear:block/netherwood_log"
+    }
+}

--- a/assets/silentgear/models/block/stripped_netherwood_log.json
+++ b/assets/silentgear/models/block/stripped_netherwood_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "silentgear:block/stripped_netherwood_log_top",
+        "side": "silentgear:block/stripped_netherwood_log",
+		"particle": "silentgear:block/stripped_netherwood_log"
+    }
+}

--- a/assets/upgrade_aquatic/models/block/driftwood_log.json
+++ b/assets/upgrade_aquatic/models/block/driftwood_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "upgrade_aquatic:block/driftwood_log_top",
+        "side": "upgrade_aquatic:block/driftwood_log",
+		"particle": "upgrade_aquatic:block/driftwood_log"
+    }
+}

--- a/assets/upgrade_aquatic/models/block/river_log.json
+++ b/assets/upgrade_aquatic/models/block/river_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "upgrade_aquatic:block/river_log_top",
+        "side": "upgrade_aquatic:block/river_log",
+		"particle": "upgrade_aquatic:block/river_log"
+    }
+}

--- a/assets/upgrade_aquatic/models/block/stripped_driftwood_log.json
+++ b/assets/upgrade_aquatic/models/block/stripped_driftwood_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "upgrade_aquatic:block/driftwood_log_top_stripped",
+        "side": "upgrade_aquatic:block/stripped_driftwood_log",
+		"particle": "upgrade_aquatic:block/stripped_driftwood_log"
+    }
+}

--- a/assets/upgrade_aquatic/models/block/stripped_river_log.json
+++ b/assets/upgrade_aquatic/models/block/stripped_river_log.json
@@ -1,0 +1,8 @@
+{
+    "parent": "block/log",
+    "textures": {
+        "top": "upgrade_aquatic:block/stripped_river_log_top",
+        "side": "upgrade_aquatic:block/stripped_river_log",
+		"particle": "upgrade_aquatic:block/stripped_river_log"
+    }
+}


### PR DESCRIPTION
Adds support for Team Abnormals, Team Aurora, Terra Incognita and Nature's Aura mods. The only log that's missing is the Crustose Aspen from Atmospheric, for reasons explained below:


![319c5a80-12a1-48c5-911e-36640ea4c2ff](https://user-images.githubusercontent.com/81559564/114284201-35723f00-9a46-11eb-967e-16c9a79accd3.jpg)
Autumnity Maple, Environmental Willow, Cherry and Wisteria


![733e3bbc-1010-4dbb-9825-2e17bc80957f](https://user-images.githubusercontent.com/81559564/114284224-59358500-9a46-11eb-8650-b6c83eeca1e4.jpg)
Endergetic Poise, Expanded Mushrooms Red Mushroom, Brown Mushroom and Glowshroom


![c9eeae0f-b4a9-466c-ba6a-2676e287d28e](https://user-images.githubusercontent.com/81559564/114284258-7e29f800-9a46-11eb-836b-8264d4267696.jpg)
Atmospheric Morado, Rosewood, Grimwood and Kousa


![e485eac1-b6e6-4b06-a0f2-554b0ce11bb1](https://user-images.githubusercontent.com/81559564/114284275-a3b70180-9a46-11eb-9f0b-a936dfcbd8e0.jpg)
Atmospheric Aspen, Yucca, Upgrade Aquatic Driftwood and River


![6cfa08f7-6ec5-460d-820a-600c577984cf](https://user-images.githubusercontent.com/81559564/114284353-32c41980-9a47-11eb-9b83-eb016359ef1c.jpg)
Terra Incognita Apple, Hazel, Abundance Jacaranda and Redbud


![44846e4e-45b3-4f8e-b466-8bb43c979296](https://user-images.githubusercontent.com/81559564/114284299-d2cd7300-9a46-11eb-9e67-24a6f64bbeea.jpg)
Bayou Blues Cypress and Nature's Aura Ancient


![cc50dbc6-70f2-430e-b1c0-7347b0416c44](https://user-images.githubusercontent.com/81559564/114284397-7b7bd280-9a47-11eb-91b2-a138055cbc31.jpg)
Sadly, since the Atmospheric Crustose Aspen uses multiple model files with differing textures to keep the crustose bit at the top, I couldn't figure out how to get it it to work.
The Atmospheric model files are here in case anyone else wants to have a go: https://github.com/team-abnormals/atmospheric/tree/main/src/main/resources/assets/atmospheric/models/block